### PR TITLE
Looping Error

### DIFF
--- a/digitize.sh
+++ b/digitize.sh
@@ -24,13 +24,15 @@ echo ""
 echo "Do you have an external hard drive you would like to store the Movie in? y/n"
 read "confirmed"
 if [ "$confirmed" == "y" ]; then
-    echo ""
-    lsblk -o NAME,TYPE,MOUNTPOINT | grep /media | awk -F"/" '{print $NF}'
+     echo ""
+    lsblk -o NAME,TYPE,MOUNTPOINT | grep /media | awk -F"/" '{print $NF}'| nl -s': '
 
-    echo "Which of these devices above would you like to store the movie on?"
+    echo "Please type a number corresponding to the device you like to store the movie on."
 
 
-    read "device_name"
+    read "device_name_input"
+
+    device_name=$(lsblk -o NAME,TYPE,MOUNTPOINT | grep /media | awk -F"/" '{print $NF}' | awk 'NR=='$device_name_input)
 
     username=$(echo $USER)
     cd /media/$username/$device_name
@@ -192,17 +194,28 @@ while true; do
             read _retry
             if [ "$_retry" == "y" ]; then
                 echo "Please enter the number of the title to encode (If you do not know please enter '0'): "
-                read "_Retry"
-                if [ "$_Retry" == "0" ]; then
+                read "_RetryVarVar"
+                if [ "$_RetryVar" == "0" ]; then
                     echo "Now going to scan disc for Main Feature movie track."
                     sleep 3
-                    HandBrakeCLI -i $dvd_devices -t "$_Retry" -o "$_MovieTitle".mp4 -e x264 -q 18 -B 192  2>&1 | tee output
+                    HandBrakeCLI -i $dvd_devices -t "$_RetryVar" -o "$_MovieTitle".mp4 -e x264 -q 18 -B 192  2>&1 | tee output
                     _MainTrack=$(grep -B1 Main output | grep title | tr -dc '0-9')
                     echo "Now going to make a digital backup of $_MovieTitle, it will be located in ~/Videos/Movie_Backups/"
                     echo "Now going to try to digitize your movie titled $_MovieTitle."
                     sleep 4
                     HandBrakeCLI -i $dvd_devices -t "$_MainTrack" -o "$_MovieTitle".mp4 -e x264
                     break
+                else
+                    echo "Now going to scan disc for Main Feature movie track."
+                    sleep 3
+                    HandBrakeCLI -i $dvd_devices -t "$_RetryVar" -o "$_MovieTitle".mp4 -e x264 -q 18 -B 192  2>&1 | tee output
+                    _MainTrack=$(grep -B1 Main output | grep title | tr -dc '0-9')
+                    echo "Now going to make a digital backup of $_MovieTitle, it will be located in ~/Videos/Movie_Backups/"
+                    echo "Now going to try to digitize your movie titled $_MovieTitle."
+                    sleep 4
+                    HandBrakeCLI -i $dvd_devices -t "$_MainTrack" -o "$_MovieTitle".mp4 -e x264
+                    break
+                    
                 fi
             else
                 if [ "$_retry" == "n" ]; then

--- a/digitize.sh
+++ b/digitize.sh
@@ -24,7 +24,7 @@ echo ""
 echo "Do you have an external hard drive you would like to store the Movie in? y/n"
 read "confirmed"
 if [ "$confirmed" == "y" ]; then
-     echo ""
+    echo ""
     lsblk -o NAME,TYPE,MOUNTPOINT | grep /media | awk -F"/" '{print $NF}'| nl -s': '
 
     echo "Please type a number corresponding to the device you like to store the movie on."
@@ -194,7 +194,7 @@ while true; do
             read _retry
             if [ "$_retry" == "y" ]; then
                 echo "Please enter the number of the title to encode (If you do not know please enter '0'): "
-                read "_RetryVarVar"
+                read "_RetryVar"
                 if [ "$_RetryVar" == "0" ]; then
                     echo "Now going to scan disc for Main Feature movie track."
                     sleep 3
@@ -214,8 +214,7 @@ while true; do
                     echo "Now going to try to digitize your movie titled $_MovieTitle."
                     sleep 4
                     HandBrakeCLI -i $dvd_devices -t "$_MainTrack" -o "$_MovieTitle".mp4 -e x264
-                    break
-                    
+                    break  
                 fi
             else
                 if [ "$_retry" == "n" ]; then


### PR DESCRIPTION
Fixed the looping when HandBreak couldn't find the title and the user would enter the title. Also added an option for the user to select a number corresponding to their preferred external hard drive rather than having to type the whole name out.